### PR TITLE
Add check for Hashtable with one element in Powershell 5.1

### DIFF
--- a/Migration.ps1
+++ b/Migration.ps1
@@ -1640,7 +1640,7 @@ function Populate-AllMachinesOnboardedToUpdateManagement
             Write-Telemetry -Message ("Zero machines retrieved from log analytics workspace. If machines were recently onboarded, please wait for few minutes for machines to start reporting to log analytics workspace") -Level $ErrorLvl
             throw
         }
-        elseif ($laResults.Results.Count -gt 0)
+        elseif ($laResults.Results.Count -gt 0 -or @($laResults.Results).Count -gt 0)
         {
             Write-Telemetry -Message ("Retrieved machines from log analytics workspace.")
 


### PR DESCRIPTION
Fixing below known issue in Powershell 5.1
https://stackoverflow.com/questions/68349957/getting-the-count-of-a-hashtable-that-only-has-one-key-value-in-it