### PR TITLE
Remove Brazil US from Dynamic Location as it is not a valid region for VMs

### DIFF
--- a/Migration.ps1
+++ b/Migration.ps1
@@ -2011,10 +2011,19 @@ function Set-DynamicScopeForMaintenanceConfiguration
                     $maintenanceConfigurationDynamicScopingPayload.location = [String]::Empty
                     $maintenanceConfigurationDynamicScopingPayload.properties.filter.resourceGroups = @($parts[4])
                 }
-    
+
+                $locations = [System.Collections.ArrayList]@()
+                foreach ($location in $azureQuery.locations)
+                {
+                    if ($location -ne "brazilus")
+                    {
+                        [void]$locations.Add($location)
+                    }
+                }
+
                 $maintenanceConfigurationDynamicScopingPayload.properties.maintenanceConfigurationId = $SoftwareUpdateConfigurationMigrationData.MaintenanceConfigurationResourceId
                 $maintenanceConfigurationDynamicScopingPayload.properties.filter.tagSettings = $azureQuery.tagSettings
-                $maintenanceConfigurationDynamicScopingPayload.properties.filter.locations = $azureQuery.locations
+                $maintenanceConfigurationDynamicScopingPayload.properties.filter.locations = $locations
                 $maintenanceConfigurationDynamicScopingPayload.properties.filter.osTypes = @($SoftwareUpdateConfiguration.properties.updateConfiguration.operatingSystem)
                     
                 $dynamicScopeConfigurationAlreadyAssigned = Validate-DynamicScopeConfigurationAlreadyAssigned -DynamicScopeConfigurationAssignments $dynamicConfigurationAssignments -MaintenanceConfigurationDynamicScopingPayload $maintenanceConfigurationDynamicScopingPayload -Scope ("/subscriptions/" + $parts[2])


### PR DESCRIPTION
# Justification
- Remove Brazil US from Dynamic Location as it is not a valid region for VMs